### PR TITLE
modify the ChatId method could not init operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ public class EventHandlers {
 
         try {
             larkClient.sendChatMessage(
-                    MessageDestinations.ChatId(event.getOpenChatId()),
+                    MessageDestinations.chatId(event.getOpenChatId()),
                     new TextMessage("Hello, I'm Echo Robot, try say to me."));
         } catch (LarkClientException e) {
             e.printStackTrace();


### PR DESCRIPTION
MessageDestinations.ChatId(event.getOpenChatId()),无法获取实例化，应该是错误，改成调用chatId方法